### PR TITLE
Add RequestNotFound error

### DIFF
--- a/fixtures/vcr_cassettes/Harvesting_Models_ProjectUserAssignment_create/with_a_project_id_creates_the_user_assignment.yml
+++ b/fixtures/vcr_cassettes/Harvesting_Models_ProjectUserAssignment_create/with_a_project_id_creates_the_user_assignment.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.harvestapp.com/v2/projects/1234/user_assignments
+    body:
+      encoding: UTF-8
+      string: '{"project_id":"1234","user_id":"5678","project":{"id":"1234"},"user":{"id":"5678"}}'
+    headers:
+      User-Agent:
+      - Harvesting Ruby Gem
+      Authorization:
+      - Bearer $HARVEST_ACCESS_TOKEN
+      Harvest-Account-Id:
+      - "$HARVEST_ACCOUNT_ID"
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.harvestapp.com
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Aug 2020 20:25:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Status:
+      - 404 Not Found
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Cache-Control:
+      - no-cache, no-store
+      P3p:
+      - 'CP="Our privacy policy is available online: https://www.getharvest.com/services/privacy-policy"'
+      X-App-Server:
+      - app1
+      X-Robots-Tag:
+      - noindex, nofollow
+      Content-Security-Policy:
+      - 'report-uri /csp_reports; default-src *; img-src * data:; font-src data: cache.harvestapp.com
+        https://fonts.gstatic.com; script-src ''self'' ''unsafe-inline'' ''unsafe-eval''
+        https://*.google-analytics.com https://*.nr-data.net https://ajax.googleapis.com
+        cache.harvestapp.com https://platform.twitter.com https://www.google.com https://www.googleadservices.com
+        https://www.googletagmanager.com https://connect.facebook.net https://googleads.g.doubleclick.net
+        https://cdn.plaid.com https://tagmanager.google.com https://bat.bing.com https://ct.capterra.com;
+        style-src ''self'' ''unsafe-inline'' cache.harvestapp.com https://www.google.com
+        https://tagmanager.google.com https://fonts.googleapis.com'
+      Hint:
+      - ''
+      X-Request-Id:
+      - 2efcf4ee8159d6a10335bc006dd1a214
+      X-Runtime:
+      - '0.044372'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":125068758,"is_project_manager":false,"is_active":true,"use_default_rates":false,"budget":null,"created_at":"2017-06-26T22:36:01Z","updated_at":"2017-06-26T22:36:01Z","hourly_rate":75.5,"project":{"id":1234,"name":"Online Store - Phase 1","code":"OS1"},"user":{"id":5678,"name":"Jim Allen"}}'
+    http_version: 
+  recorded_at: Fri, 21 Aug 2020 20:25:17 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/Harvesting_Models_ProjectUserAssignment_create/without_a_project_id_raises_Harvesting_RequestNotFound_error.yml
+++ b/fixtures/vcr_cassettes/Harvesting_Models_ProjectUserAssignment_create/without_a_project_id_raises_Harvesting_RequestNotFound_error.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.harvestapp.com/v2/projects//user_assignments
+    body:
+      encoding: UTF-8
+      string: '{"project_id":null,"user_id":"5678","project":{"id":null},"user":{"id":"5678"}}'
+    headers:
+      User-Agent:
+      - Harvesting Ruby Gem
+      Authorization:
+      - Bearer $HARVEST_ACCESS_TOKEN
+      Harvest-Account-Id:
+      - "$HARVEST_ACCOUNT_ID"
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.harvestapp.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Aug 2020 20:25:16 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Content-Length:
+      - '4044'
+      Connection:
+      - close
+      Status:
+      - 404 Not Found
+      X-Request-Id:
+      - 47a13ab18fb6e5f8f85c2827e9b782da
+      X-Runtime:
+      - '0.028918'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta http-equiv="Pragma" content="no-cache" />
+          <title>HARVEST: Canʼt find page</title>
+
+          <!-- Global site tag (gtag.js) - Google Analytics -->
+          <script async src="https://www.googletagmanager.com/gtag/js?id=UA-103886-9"></script>
+          <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-103886-9', {cookie_flags: 'max-age=7200;secure;samesite=none'});
+          </script>
+
+          <script>
+            <!--
+
+            var accounturl = null;
+
+            function url_test() {
+              accounturl = window.location.href.substr(0, window.location.href.search(/\.com/)+4);
+              if(window.location.port) accounturl += ":" + window.location.port;
+              accounturl += "/";
+
+              var host = window.location.hostname;
+              var wwwexp = /www/;
+
+              if(!wwwexp.test(host)){
+                var re = new RegExp(/^([^.]+)\..*$/);
+                var m = re.exec(host);
+                if (m != null && m[1]!="www" && m[1]!="localhost"){
+                  document.getElementById('account404').style.display = 'list-item';
+                  document.getElementById('market404').style.display = 'none';
+                }
+              }
+            }
+
+            // End -->
+          </script>
+          <style type="text/css">
+            body {
+              font: 12px/16px "Lucida Grande", Helvetica, Arial, Verdana, sans-serif;
+              background:#e7e7e7;
+              color: #333;
+            }
+
+            a {color: #F60;}
+            a:hover { color: #F60; text-decoration: none;}
+
+            div#header {height:36px; border-bottom: 1px solid #bbb; margin-bottom:20px; }
+            h1 { float:left; margin: 0 10px 0 0; }
+            h1 a { display:block; height: 24px; }
+            h2 {font-size: 16px; line-height: 1.4em; color: #000; margin: 0;}
+
+            .container {background-color: #ddd; padding: 3px; width:450px; margin: 50px auto 20px auto; border-radius: 12px }
+            .content {background-color: #fff; border: 1px solid #aaa; padding: 30px; border-radius: 8px}
+
+            p {margin: 1em 0;}
+
+            ul { text-indent:0; margin: 1em 0 0 0; padding:0; list-style:none; }
+            ul li { margin: 0 0 .7em; font-size:130%; }
+
+
+          </style>
+        </head>
+        <body>
+          <div class="container">
+            <div class="content">
+              <div id="header">
+                <h1>
+                  <a href="http://www.getharvest.com/">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="128" height="24" viewBox="0 0 128 24">
+                      <g fill="#E3682C" fill-rule="evenodd">
+                        <path d="M0 23.07V.24h4.36v9.1h6.17V.25h4.36v22.83h-4.37V13.2H4.36v9.87H0M25.33 14.4h4.33L27.54 5.2h-.06l-2.15 9.23zm-6.23 8.67L24.76.24h5.6l5.5 22.83H31.7l-1.12-4.8h-6.04l-1.23 4.8h-4.2zm25.08-12.9h2.24c1.93 0 3.1-.95 3.1-3.16 0-2.2-1.17-3.15-3.1-3.15h-2.24v6.32zm5.88 12.9l-3.8-9.3h-2.08v9.3H39.8V.24h6.34c5.25 0 7.74 2.53 7.74 6.83 0 2.85-1 4.9-3.44 5.82l4.3 10.17h-4.68zM57.5.24h4.3l4 16.32h.07L69.85.24h4.27L68.3 23.07h-4.96L57.5.24M78.14 23.07V.24H90.1V4.1h-7.6v5.25h5.8v3.86h-5.8v6.02h7.9v3.85H78.15M101.96 3.6c-1.55 0-2.4.94-2.4 2.48 0 3.44 9.7 3.7 9.7 10.82 0 3.9-2.67 6.5-7.24 6.5-3.53 0-6.27-1.93-7.44-6.4l4.3-.92c.5 2.74 2.07 3.72 3.36 3.72 1.5 0 2.68-1 2.68-2.7 0-4.3-9.7-4.36-9.7-10.73 0-3.9 2.32-6.37 6.83-6.37 3.88 0 6.24 2.3 7 5.52l-3.9 1.13c-.73-2.14-1.68-3.06-3.2-3.06zM127.9.24V4.1h-5.08v18.97h-4.36V4.1h-5.1V.24h14.55"/>
+                      </g>
+                    </svg>
+                  </a>
+                </h1>
+              </div>
+              <h2>We canʼt find the page youʼre looking for.</h2>
+
+              <p>
+                Sorry about that! The page you were looking for may have been moved or the address misspelled.
+              </p>
+
+              <ul>
+                <li id="market404">Go to the <a href="http://www.getharvest.com/">Harvest home page</a> or <a href="https://www.getharvest.com/contact">Contact Support</a></li>
+                <li id="account404" style="display:none;">Go to <a href="/" onClick="window.location = accounturl; return false;">Your Harvest Account</a> or <a href="https://www.getharvest.com/contact">Contact Support</a></li>
+              </ul>
+              <script>
+               <!--
+                url_test();
+               //-->
+              </script>
+            </div>
+          </div>
+        </body>
+        </html>
+    http_version: 
+  recorded_at: Fri, 21 Aug 2020 20:25:16 GMT
+recorded_with: VCR 4.0.0

--- a/lib/harvesting/client.rb
+++ b/lib/harvesting/client.rb
@@ -148,6 +148,9 @@ module Harvesting
 
       raise Harvesting::AuthenticationError.new(response.to_s) if auth_error?(response)
       raise Harvesting::UnprocessableRequest.new(response.to_s) if response.code.to_i == 422
+      if response.code.to_i == 404
+        raise Harvesting::RequestNotFound.new('The page you were looking for may have been moved or the address misspelled.')
+      end
 
       response
     end

--- a/lib/harvesting/client.rb
+++ b/lib/harvesting/client.rb
@@ -148,9 +148,7 @@ module Harvesting
 
       raise Harvesting::AuthenticationError.new(response.to_s) if auth_error?(response)
       raise Harvesting::UnprocessableRequest.new(response.to_s) if response.code.to_i == 422
-      if response.code.to_i == 404
-        raise Harvesting::RequestNotFound.new('The page you were looking for may have been moved or the address misspelled.')
-      end
+      raise Harvesting::RequestNotFound.new(uri) if response.code.to_i == 404
 
       response
     end

--- a/lib/harvesting/errors.rb
+++ b/lib/harvesting/errors.rb
@@ -6,5 +6,8 @@ module Harvesting
   end
 
   class RequestNotFound < StandardError
+    def initialize(uri)
+      super( "The page you were looking for may have been moved or the address misspelled: #{uri}")
+    end
   end
 end

--- a/lib/harvesting/errors.rb
+++ b/lib/harvesting/errors.rb
@@ -4,4 +4,7 @@ module Harvesting
 
   class UnprocessableRequest < StandardError
   end
+
+  class RequestNotFound < StandardError
+  end
 end

--- a/spec/harvesting/models/project_user_assignment_spec.rb
+++ b/spec/harvesting/models/project_user_assignment_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Harvesting::Models::ProjectUserAssignment, :vcr do
+  let(:attrs) { {} }
+  let(:user_assignment) { Harvesting::Models::ProjectUserAssignment.new(attrs) }
+
+  describe '#create' do
+    context 'without a project id' do
+      let(:attrs) do
+        {
+          'project' => { 'id' => nil },
+          'user' => { 'id' => '5678' }
+        }
+      end
+
+      it 'raises Harvesting::RequestNotFound error' do
+        expect { user_assignment.create }.to raise_error(Harvesting::RequestNotFound)
+      end
+    end
+
+    context 'with a project id' do
+      let(:attrs) do
+        {
+          'project' => { 'id' => '1234' },
+          'user' => { 'id' => '5678' }
+        }
+      end
+      it 'creates the user assignment' do
+        user_assignment.create
+        expect(user_assignment.id).to eq(125_068_758)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi! :wave: I leave a small contribution here, thank you for developing this gem. This error happened to me in a system I'm working on and I use a workaround to handle it, but I thought it might be useful if I fix the error directly in the gem, hope you like it!

refers to https://github.com/fastruby/harvesting/issues/55

------------

### What changes does this PR include?

**Description**

When a user tries to create a new assignment in a project the gem does the next:

`POST /v2/projects/{PROJECT_ID}/user_assignments`

 The problem is that the `PROJECT_ID` could be `nil` (in the worst-case scenario), so the response of Harvest API is an HTML body (in a string) with `404` HTTP code.

<img width="515" alt="Screen Shot 2020-08-21 at 17 36 14" src="https://user-images.githubusercontent.com/24940330/90932331-d1c2d500-e3d4-11ea-8422-6414e3a53595.png">

Harvesting tries to parse this HTML as a JSON and fails

```
    def create(entity)
      url = "#{DEFAULT_HOST}/#{entity.path}"
      uri = URI(url)
      response = http_response(:post, uri, body: entity.to_hash)
      entity.attributes = JSON.parse(response.body) #### this line
      entity
    end
```

This raises a `JSONParse::Error` because is trying to parse an HTML response, and this error is not being rescued anywhere and handling it in a proper way. This PR fixes that situation :)

**Summary**

- Added `Harvesting::RequestNotFound` to `errors.rb`.
- Added `Harvesting::RequestNotFound` rescue to `client.rb`.
