### PR TITLE
update http gem for Ruby 3.0 compatibility

### DIFF
--- a/harvesting.gemspec
+++ b/harvesting.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "http", ">= 3.3", "< 5.0"
+  spec.add_dependency "http", "~>4", "< 5.0"
 
   spec.add_development_dependency "bundler", ">= 2.0", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This isn't my branch or fork, but I did verify it fixes a Ruby 3.0 frozen string literal issue in http 3.3.0.