### PR TITLE
Define the modeled association on the child class

### DIFF
--- a/lib/harvesting/models/base.rb
+++ b/lib/harvesting/models/base.rb
@@ -108,7 +108,7 @@ module Harvesting
       def self.modeled(opts = {})
         opts.each do |attribute_name, model|
           attribute_name_string = attribute_name.to_s
-          Harvesting::Models::Base.send :define_method, attribute_name_string do
+          define_method(attribute_name_string) do
             @models[attribute_name_string] ||= model.new(@attributes[attribute_name_string] || {}, harvest_client: harvest_client)
           end
         end


### PR DESCRIPTION
Defining the association on the Base class adds the modeled method to all subclasses of Base. This PR updates `modeled` to work like `attributed`. Associations will be correctly memoized in the instance of the parent class.